### PR TITLE
Composer update with 7 changes 2022-11-25

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.247.0",
+            "version": "3.247.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "2cd51e75e753dfe1f1677bb0a2e13a9ce70cba26"
+                "reference": "00542e760d8464e0ee635f916841fdfbd1ceb95c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2cd51e75e753dfe1f1677bb0a2e13a9ce70cba26",
-                "reference": "2cd51e75e753dfe1f1677bb0a2e13a9ce70cba26",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/00542e760d8464e0ee635f916841fdfbd1ceb95c",
+                "reference": "00542e760d8464e0ee635f916841fdfbd1ceb95c",
                 "shasum": ""
             },
             "require": {
@@ -146,9 +146,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.247.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.247.2"
             },
-            "time": "2022-11-21T21:31:13+00:00"
+            "time": "2022-11-23T19:35:36+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -1545,16 +1545,16 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.21.0",
+            "version": "2.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "e5b6419fea007b8b4a71034edc8ec96c88d4c57d"
+                "reference": "df8c7f9e11d854269f4aa7c06ffa38caa42e4405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/e5b6419fea007b8b4a71034edc8ec96c88d4c57d",
-                "reference": "e5b6419fea007b8b4a71034edc8ec96c88d4c57d",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/df8c7f9e11d854269f4aa7c06ffa38caa42e4405",
+                "reference": "df8c7f9e11d854269f4aa7c06ffa38caa42e4405",
                 "shasum": ""
             },
             "require": {
@@ -1638,7 +1638,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-11T09:01:24+00:00"
+            "time": "2022-11-22T05:54:54+00:00"
         },
         {
             "name": "laravel/fortify",
@@ -1705,16 +1705,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.40.1",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "9611fdaf2db5759b8299802d7185bcdbee0340bb"
+                "reference": "cc902ce61b4ca08ca7449664cfab2fa96a1d1e28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/9611fdaf2db5759b8299802d7185bcdbee0340bb",
-                "reference": "9611fdaf2db5759b8299802d7185bcdbee0340bb",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/cc902ce61b4ca08ca7449664cfab2fa96a1d1e28",
+                "reference": "cc902ce61b4ca08ca7449664cfab2fa96a1d1e28",
                 "shasum": ""
             },
             "require": {
@@ -1887,7 +1887,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-15T16:13:22+00:00"
+            "time": "2022-11-22T15:10:46+00:00"
         },
         {
             "name": "laravel/jetstream",
@@ -1961,16 +1961,16 @@
         },
         {
             "name": "laravel/octane",
-            "version": "v1.3.8",
+            "version": "v1.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/octane.git",
-                "reference": "87833f7246992e2652f907104f5c9cf25daa1679"
+                "reference": "3e8961616b33401c7e80d62be3b38affe348c001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/octane/zipball/87833f7246992e2652f907104f5c9cf25daa1679",
-                "reference": "87833f7246992e2652f907104f5c9cf25daa1679",
+                "url": "https://api.github.com/repos/laravel/octane/zipball/3e8961616b33401c7e80d62be3b38affe348c001",
+                "reference": "3e8961616b33401c7e80d62be3b38affe348c001",
                 "shasum": ""
             },
             "require": {
@@ -2033,7 +2033,7 @@
                 "issues": "https://github.com/laravel/octane/issues",
                 "source": "https://github.com/laravel/octane"
             },
-            "time": "2022-11-11T14:45:14+00:00"
+            "time": "2022-11-19T18:40:21+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -2299,16 +2299,16 @@
         },
         {
             "name": "laravel/vapor-cli",
-            "version": "v1.47.0",
+            "version": "v1.49.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/vapor-cli.git",
-                "reference": "01ecf3e42dba13501324b25142fbe821fcba84a0"
+                "reference": "6e91cde113aee78e4b225594ebe5d8cf01b43a5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/vapor-cli/zipball/01ecf3e42dba13501324b25142fbe821fcba84a0",
-                "reference": "01ecf3e42dba13501324b25142fbe821fcba84a0",
+                "url": "https://api.github.com/repos/laravel/vapor-cli/zipball/6e91cde113aee78e4b225594ebe5d8cf01b43a5e",
+                "reference": "6e91cde113aee78e4b225594ebe5d8cf01b43a5e",
                 "shasum": ""
             },
             "require": {
@@ -2361,9 +2361,9 @@
                 "vapor"
             ],
             "support": {
-                "source": "https://github.com/laravel/vapor-cli/tree/v1.47.0"
+                "source": "https://github.com/laravel/vapor-cli/tree/v1.49.0"
             },
-            "time": "2022-11-18T15:11:05+00:00"
+            "time": "2022-11-23T15:18:31+00:00"
         },
         {
             "name": "laravel/vapor-core",
@@ -5383,16 +5383,16 @@
         },
         {
             "name": "revolution/laravel-line-sdk",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/laravel-line-sdk.git",
-                "reference": "53b0bee7a279711ee07dec870aec9a03bd1edb43"
+                "reference": "13b85b259b45743df7c24875278839af391d756d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/laravel-line-sdk/zipball/53b0bee7a279711ee07dec870aec9a03bd1edb43",
-                "reference": "53b0bee7a279711ee07dec870aec9a03bd1edb43",
+                "url": "https://api.github.com/repos/kawax/laravel-line-sdk/zipball/13b85b259b45743df7c24875278839af391d756d",
+                "reference": "13b85b259b45743df7c24875278839af391d756d",
                 "shasum": ""
             },
             "require": {
@@ -5441,9 +5441,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kawax/laravel-line-sdk/issues",
-                "source": "https://github.com/kawax/laravel-line-sdk/tree/2.0.1"
+                "source": "https://github.com/kawax/laravel-line-sdk/tree/2.0.2"
             },
-            "time": "2022-02-17T04:57:00+00:00"
+            "time": "2022-11-25T00:24:59+00:00"
         },
         {
             "name": "revolution/laravel-str-mixins",
@@ -9715,16 +9715,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.16.2",
+            "version": "v1.16.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "7d1ed5f856ec8b9708712e3fc0708fcabe114659"
+                "reference": "0dbee8802e17911afbe29a8506316343829b056e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/7d1ed5f856ec8b9708712e3fc0708fcabe114659",
-                "reference": "7d1ed5f856ec8b9708712e3fc0708fcabe114659",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/0dbee8802e17911afbe29a8506316343829b056e",
+                "reference": "0dbee8802e17911afbe29a8506316343829b056e",
                 "shasum": ""
             },
             "require": {
@@ -9771,7 +9771,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2022-09-28T13:13:22+00:00"
+            "time": "2022-11-21T16:19:18+00:00"
         },
         {
             "name": "mockery/mockery",


### PR DESCRIPTION
  - Upgrading aws/aws-sdk-php (3.247.0 => 3.247.2)
  - Upgrading laminas/laminas-diactoros (2.21.0 => 2.22.0)
  - Upgrading laravel/framework (v9.40.1 => v9.41.0)
  - Upgrading laravel/octane (v1.3.8 => v1.3.9)
  - Upgrading laravel/sail (v1.16.2 => v1.16.3)
  - Upgrading laravel/vapor-cli (v1.47.0 => v1.49.0)
  - Upgrading revolution/laravel-line-sdk (2.0.1 => 2.0.2)
